### PR TITLE
Added ability to set response type

### DIFF
--- a/SlackBotMessages.Tests/BasicTests.cs
+++ b/SlackBotMessages.Tests/BasicTests.cs
@@ -390,5 +390,35 @@ namespace SlackBotMessages.Tests
             var response = client.Send(message);
             Assert.AreEqual("ok", response.Result);
         }
+
+        /// <summary>
+        ///     This example shows you how you can send response via in_channel
+        /// </summary>
+        [Test]
+        public void Response_In_Channel()
+        {
+            var client = new SbmClient(WebHookUrl);
+
+            var message = new Message("This is an in_channel response type.");
+
+            message.SetResponseType(ResponseType.in_channel);
+            var response = client.Send(message);
+            Assert.AreEqual("ok", response.Result);
+        }
+
+        /// <summary>
+        ///     This example shows you how you can send response via ephemeral
+        /// </summary>
+        [Test]
+        public void Response_In_Ephemeral()
+        {
+            var client = new SbmClient(WebHookUrl);
+
+            var message = new Message("This is an ephemeral response type.");
+
+            message.SetResponseType(ResponseType.ephemeral);
+            var response = client.Send(message);
+            Assert.AreEqual("ok", response.Result);
+        }
     }
 }

--- a/SlackBotMessages.Tests/BasicTestsAsync.cs
+++ b/SlackBotMessages.Tests/BasicTestsAsync.cs
@@ -406,5 +406,37 @@ namespace SlackBotMessages.Tests
             var response = await client.SendAsync(message).ConfigureAwait(false);
             Assert.AreEqual("ok", response);
         }
+
+        /// <summary>
+        ///     This example shows you how you can send response via in_channel
+        ///     using the SendAsync method
+        /// </summary>
+        [Test]
+        public async Task Response_In_Channel_Async()
+        {
+            var client = new SbmClient(WebHookUrl);
+
+            var message = new Message("This is an in_channel response type.");
+
+            message.SetResponseType(ResponseType.in_channel);
+            var response = await client.SendAsync(message);
+            Assert.AreEqual("ok", response);
+        }
+
+        /// <summary>
+        ///     This example shows you how you can send response via ephemeral
+        ///     using the SendAsync method
+        /// </summary>
+        [Test]
+        public async Task Response_In_Ephemeral_Async()
+        {
+            var client = new SbmClient(WebHookUrl);
+
+            var message = new Message("This is an ephemeral response type.");
+
+            message.SetResponseType(ResponseType.ephemeral);
+            var response = await client.SendAsync(message);
+            Assert.AreEqual("ok", response);
+        }
     }
 }

--- a/SlackBotMessages/Enums/ResponseType.cs
+++ b/SlackBotMessages/Enums/ResponseType.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace SlackBotMessages.Enums
+{
+    public enum ResponseType
+    {
+        /// <summary>
+        /// Responses are visible to the entire channel
+        /// </summary>
+        in_channel,
+
+        /// <summary>
+        /// Responses are just visible to the user
+        /// </summary>
+        ephemeral
+    }
+}

--- a/SlackBotMessages/Enums/ResponseType.cs
+++ b/SlackBotMessages/Enums/ResponseType.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace SlackBotMessages.Enums
+﻿namespace SlackBotMessages.Enums
 {
     public enum ResponseType
     {

--- a/SlackBotMessages/Models/Message.cs
+++ b/SlackBotMessages/Models/Message.cs
@@ -78,7 +78,7 @@ namespace SlackBotMessages.Models
         [JsonProperty("response_type")]
         private string ResponseType
         {
-            get => string.IsNullOrEmpty(_responseType) ? "in_channel" : _responseType;
+            get => string.IsNullOrEmpty(_responseType) ? "ephemeral" : _responseType;
             set => _responseType = value;
         }
 

--- a/SlackBotMessages/Models/Message.cs
+++ b/SlackBotMessages/Models/Message.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using SlackBotMessages.Enums;
 
 namespace SlackBotMessages.Models
 {
     public class Message
     {
+        private string _responseType;
+
         /// <summary>
         ///     Create a message
         /// </summary>
@@ -72,6 +75,13 @@ namespace SlackBotMessages.Models
         [JsonProperty("attachments")]
         public List<Attachment> Attachments { get; set; }
 
+        [JsonProperty("response_type")]
+        private string ResponseType
+        {
+            get => string.IsNullOrEmpty(_responseType) ? "in_channel" : _responseType;
+            set => _responseType = value;
+        }
+
         /// <summary>
         ///     Add an attachment to the message
         /// </summary>
@@ -119,6 +129,17 @@ namespace SlackBotMessages.Models
         public Message SetChannel(string channel)
         {
             Channel = channel;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets the response type to either reply to the entire channel or to just the user. Helpful for Slash Commands. Default is InChannel.
+        /// </summary>
+        /// <param name="responseType">How you want the response to be displayed.</param>
+        /// <returns></returns>
+        public Message SetResponseType(ResponseType responseType)
+        {
+            ResponseType = responseType.ToString();
             return this;
         }
     }


### PR DESCRIPTION
Without .NET Standard 2.0 there really isn't a nice way to get a Display/Description attribute. So, here's an easy implementation without any further changes. 

The response type defaults to ephemeral.